### PR TITLE
Add "to-style" as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "react-typography": "^0.16.19",
     "rebass": "^3.1.0",
     "styled-components": "^4.2.0",
+    "to-style": "^1.3.3",
     "typeface-source-sans-pro": "^0.0.54",
     "typography": "^0.16.19",
     "typography-theme-fairy-gates": "^0.16.19"


### PR DESCRIPTION
`$ gatsby develeop` results in:

```
 ERROR

Error in ".../coolest-library/node_modules/gatsby-mdx/gatsby-node.js": Cannot find module 'to-style'
Require stack:
- .../coolest-library/node_modules/gatsby-mdx/utils/babel-plugin-html-attr-to-jsx-attr.js
- .../coolest-library/node_modules/gatsby-mdx/utils/gen-mdx.js
- .../coolest-library/node_modules/gatsby-mdx/gatsby/on-create-node.js
- .../coolest-library/node_modules/gatsby-mdx/gatsby-node.js
- .../coolest-library/node_modules/gatsby/dist/bootstrap/resolve-module-exports.js
- .../coolest-library/node_modules/gatsby/dist/bootstrap/load-plugins/validate.js
- .../coolest-library/node_modules/gatsby/dist/bootstrap/load-plugins/load.js
- .../coolest-library/node_modules/gatsby/dist/bootstrap/load-plugins/index.js
- .../coolest-library/node_modules/gatsby/dist/bootstrap/index.js
- .../coolest-library/node_modules/gatsby/dist/commands/develop-process.js
- .../coolest-library/.cache/tmp-72966-rx371F9bJSQN
```

Error solved by adding "to-style": "^1.3.3" as a dependency.